### PR TITLE
Fix double ', case and period in load.ffdf()

### DIFF
--- a/pkg/R/save_ffdf.R
+++ b/pkg/R/save_ffdf.R
@@ -115,7 +115,7 @@ move.ffdf <- function(x, dir=".", name=as.character(substitute(x)), relativepath
 #' @export
 load.ffdf <- function(dir, envir=parent.frame()){
   if (!isTRUE(file.exists(dir))){
-    stop("Directory '", dir ,"'' does not exist.")
+    stop("directory '", dir ,"' does not exist")
   }
   oldwd <- setwd(dir)
   on.exit(setwd(oldwd))


### PR DESCRIPTION
Slight detail related to the fix for issue #16. This is what the R Writing Extensions manual says error messages should look like.
