### PR TITLE
Add failing test for ffbase::format.ff_vector

### DIFF
--- a/pkg/tests/testthat/testformat.R
+++ b/pkg/tests/testthat/testformat.R
@@ -1,0 +1,18 @@
+library(testthat)
+library(ff)
+library(ffbase)
+
+context("format.ff_vector")
+
+test_that("format accepts positional parameters",{
+		  datevec <- rep(as.POSIXct("2016/08/02 18:12:54"), 3)
+		  ffdatevec <- ff(datevec)
+		  expect_equal(ff(factor(rep("2016", 3))), format(ffdatevec, "%Y"))
+})
+
+test_that("format accepts named parametest",{
+		  datevec <- rep(as.POSIXct("2016/08/02 18:12:54"), 3)
+		  ffdatevec <- ff(datevec)
+		  expect_equal(ff(factor(rep("2016", 3))), format(ffdatevec, format="%Y"))
+})
+


### PR DESCRIPTION
In lieu of submitting a bug report, here are failing and passing tests for `format.ff_vector` that illustrate the issue. Positional format string parameters passed to format.ff_vector cause an error to be thrown, due to the way parameters are passed to chunk.