### PR TITLE
Replaces Sint types with int types

### DIFF
--- a/pkg/src/grouprunningcumsum.c
+++ b/pkg/src/grouprunningcumsum.c
@@ -10,7 +10,7 @@
  */
 #include <R.h>
 
-void grouprunningcumsum(Sint *x, Sint *l, Sint *max) {   
+void grouprunningcumsum(int *x, int *l, int *max) {   
 		int i, size=*l, xinit=*x, maxsize, runningcumul=0;
 		maxsize = max[0];
     for (i = 0; i < size; i++){

--- a/pkg/src/grouprunningcumsumindex.c
+++ b/pkg/src/grouprunningcumsumindex.c
@@ -11,7 +11,7 @@
  */
 #include <R.h>
 
-void grouprunningcumsumindex(Sint *x, Sint *l, Sint *max, Sint *currentcumul) {   
+void grouprunningcumsumindex(int *x, int *l, int *max, int *currentcumul) {   
 		int i, size=*l, xinit=*x, maxsize, runningcumul;
 		maxsize = max[0];
 		runningcumul = currentcumul[0];


### PR DESCRIPTION
According to the R 4.3.0 release notes

> The deprecated legacy typedefs of Sint and Sfloat in header ‘R.h’ are no longer defined, and that header no longer includes header ‘limits.h’ from C nor ‘climits’ from C++.

Sint was defined in R.h simply as:

`typedef int Sint`

So I just replaced all references to Sint with int!